### PR TITLE
Add basic admin page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -19,6 +19,7 @@ import { ManisfesteComponent } from './core/manisfeste/manisfeste.component';
 import { ShopifyModalProductComponent } from './composant/shopify-modal-product/shopify-modal-product.component';
 import { NewsDetailComponent } from './composant/news-detail/news-detail.component';
 import { PolitiqueComponent } from './composant/politique/politique.component';
+import { AdminComponent } from './core/component/admin/admin.component';
 
 export const routes: Routes = [
   { path: 'home', component: HomeComponent, canActivate: [mobileNotAllowedGuard] },
@@ -35,6 +36,7 @@ export const routes: Routes = [
   { path: 'signup', component: SignupComponent, canActivate: [mobileNotAllowedGuard] },
   { path: 'mentions', component: MentionsComponent },
   { path: 'privacy-policy', component: PolitiqueComponent },
+  { path: 'admin', component: AdminComponent },
   { path: 'release', component: ReleaseComponent, canActivate: [mobileNotAllowedGuard] },
   { path: 'profile', component: ProfileComponent, canActivate: [mobileNotAllowedGuard] },
   { path: 'confirm-email', component: VerifyEmailComponent, canActivate: [mobileNotAllowedGuard] },

--- a/src/app/core/component/admin/admin.component.html
+++ b/src/app/core/component/admin/admin.component.html
@@ -1,0 +1,82 @@
+<mat-toolbar color="primary">Administration</mat-toolbar>
+
+<mat-card>
+  <h2>Langages</h2>
+  <table mat-table [dataSource]="langages" class="mat-elevation-z8">
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef>Nom</th>
+      <td mat-cell *matCellDef="let l">{{ l.name }}</td>
+    </ng-container>
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef>Actions</th>
+      <td mat-cell *matCellDef="let l">
+        <button mat-icon-button color="warn" (click)="deleteLangage(l._id)">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="['name','actions']"></tr>
+    <tr mat-row *matRowDef="let row; columns: ['name','actions'];"></tr>
+  </table>
+  <form (ngSubmit)="createLangage()">
+    <mat-form-field>
+      <input matInput placeholder="Nom" [(ngModel)]="newLangage.name" name="name">
+    </mat-form-field>
+    <button mat-raised-button color="primary" type="submit">Ajouter</button>
+  </form>
+</mat-card>
+
+<mat-card>
+  <h2>Utilisateurs</h2>
+  <table mat-table [dataSource]="users" class="mat-elevation-z8">
+    <ng-container matColumnDef="email">
+      <th mat-header-cell *matHeaderCellDef>Email</th>
+      <td mat-cell *matCellDef="let u">{{ u.email }}</td>
+    </ng-container>
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef>Actions</th>
+      <td mat-cell *matCellDef="let u">
+        <button mat-icon-button color="warn" (click)="deleteUser(u._id)">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="['email','actions']"></tr>
+    <tr mat-row *matRowDef="let row; columns: ['email','actions'];"></tr>
+  </table>
+  <form (ngSubmit)="createUser()">
+    <mat-form-field>
+      <input matInput placeholder="Email" [(ngModel)]="newUser.email" name="email">
+    </mat-form-field>
+    <mat-form-field>
+      <input matInput placeholder="Password" [(ngModel)]="newUser.password" name="password" type="password">
+    </mat-form-field>
+    <button mat-raised-button color="primary" type="submit">Ajouter</button>
+  </form>
+</mat-card>
+
+<mat-card>
+  <h2>Articles</h2>
+  <table mat-table [dataSource]="articles" class="mat-elevation-z8">
+    <ng-container matColumnDef="title">
+      <th mat-header-cell *matHeaderCellDef>Titre</th>
+      <td mat-cell *matCellDef="let a">{{ a.title }}</td>
+    </ng-container>
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef>Actions</th>
+      <td mat-cell *matCellDef="let a">
+        <button mat-icon-button color="warn" (click)="deleteArticle(a._id)">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="['title','actions']"></tr>
+    <tr mat-row *matRowDef="let row; columns: ['title','actions'];"></tr>
+  </table>
+  <form (ngSubmit)="createArticle()">
+    <mat-form-field>
+      <input matInput placeholder="Titre" [(ngModel)]="newArticle.title" name="title">
+    </mat-form-field>
+    <button mat-raised-button color="primary" type="submit">Ajouter</button>
+  </form>
+</mat-card>

--- a/src/app/core/component/admin/admin.component.scss
+++ b/src/app/core/component/admin/admin.component.scss
@@ -1,0 +1,7 @@
+mat-card {
+  margin: 1rem 0;
+}
+
+mat-form-field {
+  margin-right: 1rem;
+}

--- a/src/app/core/component/admin/admin.component.ts
+++ b/src/app/core/component/admin/admin.component.ts
@@ -1,0 +1,100 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatTableModule } from '@angular/material/table';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatCardModule } from '@angular/material/card';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { LangagesService } from '../../../services/langages.service';
+import { UsersService } from '../../../services/users.service';
+import { ArticlesService } from '../../../services/articles.service';
+
+@Component({
+  selector: 'app-admin',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatTableModule,
+    MatButtonModule,
+    MatIconModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatCardModule,
+    MatToolbarModule
+  ],
+  templateUrl: './admin.component.html',
+  styleUrl: './admin.component.scss'
+})
+export class AdminComponent implements OnInit {
+  langages: any[] = [];
+  users: any[] = [];
+  articles: any[] = [];
+
+  newLangage: any = {};
+  newUser: any = {};
+  newArticle: any = {};
+
+  constructor(
+    private langagesService: LangagesService,
+    private usersService: UsersService,
+    private articlesService: ArticlesService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadLangages();
+    this.loadUsers();
+    this.loadArticles();
+  }
+
+  loadLangages() {
+    this.langagesService.getAllLangages().subscribe(data => this.langages = data);
+  }
+
+  loadUsers() {
+    this.usersService.getAllUsers().subscribe(data => this.users = data);
+  }
+
+  loadArticles() {
+    this.articlesService.getArticles().subscribe(data => this.articles = data);
+  }
+
+  createLangage() {
+    if (!this.newLangage.name) return;
+    this.langagesService.createLangage(this.newLangage).subscribe(() => {
+      this.loadLangages();
+      this.newLangage = {};
+    });
+  }
+
+  deleteLangage(id: string) {
+    this.langagesService.deleteLangage(id).subscribe(() => this.loadLangages());
+  }
+
+  createUser() {
+    if (!this.newUser.email) return;
+    this.usersService.createUser(this.newUser).subscribe(() => {
+      this.loadUsers();
+      this.newUser = {};
+    });
+  }
+
+  deleteUser(id: string) {
+    this.usersService.deleteUser(id).subscribe(() => this.loadUsers());
+  }
+
+  createArticle() {
+    if (!this.newArticle.title) return;
+    this.articlesService.createArticle(this.newArticle).subscribe(() => {
+      this.loadArticles();
+      this.newArticle = {};
+    });
+  }
+
+  deleteArticle(id: string) {
+    this.articlesService.deleteArticle(id).subscribe(() => this.loadArticles());
+  }
+}

--- a/src/app/navigation/header/header.component.html
+++ b/src/app/navigation/header/header.component.html
@@ -29,6 +29,9 @@
             <li class="" *isDesktopOnly>
                 <a class="" routerLink="/shop" routerLinkActive="active">boutique</a>
             </li>
+            <li class="" *isDesktopOnly>
+                <a class="" routerLink="/admin" routerLinkActive="active">admin</a>
+            </li>
         </ul>
     </div>
 

--- a/src/app/navigation/sidenav/sidenav.component.html
+++ b/src/app/navigation/sidenav/sidenav.component.html
@@ -22,6 +22,9 @@
     <a mat-list-item routerLink="/shop" (click)="onSidenavClose()">
         <mat-icon>storefront</mat-icon> <span class="nav-caption">boutique</span>
     </a>
+    <a mat-list-item routerLink="/admin" (click)="onSidenavClose()" *isDesktopOnly>
+        <mat-icon>admin_panel_settings</mat-icon> <span class="nav-caption">admin</span>
+    </a>
 
 
     @if(isAuthenticated){<a mat-list-item routerLink="/profile" (click)="onSidenavClose()" *isDesktopOnly>

--- a/src/app/services/articles.service.ts
+++ b/src/app/services/articles.service.ts
@@ -25,4 +25,16 @@ export class ArticlesService {
   getArticleById(id: string): Observable<Article> {
     return this.http.get<Article>(`${this.apiUrl}/${id}`);
   }
+
+  createArticle(data: any): Observable<any> {
+    return this.http.post(this.apiUrl, data);
+  }
+
+  deleteArticle(id: string): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/${id}`);
+  }
+
+  updateArticle(id: string, data: any): Observable<any> {
+    return this.http.patch(`${this.apiUrl}/${id}`, data);
+  }
 }

--- a/src/app/services/langages.service.ts
+++ b/src/app/services/langages.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { map, Observable } from 'rxjs';
 
@@ -8,15 +8,31 @@ import { map, Observable } from 'rxjs';
 
 export class LangagesService {
 
-  private apiLangagesUrl = 'api/langages/all';
+  private apiLangagesUrl = 'api/langages';
 
   constructor(private http: HttpClient) { }
 
   getAllLangages(): Observable<any[]> {
-    return this.http.get<any[]>(this.apiLangagesUrl).pipe(
+    return this.http.get<any[]>(`${this.apiLangagesUrl}/all`).pipe(
       map((langages: any) => {
       return  langages.sort((a: any,b: any) => (b.recommendations ?? 0) - (a.recommendations ?? 0))
       })
     )
+  }
+
+  createLangage(data: any): Observable<any> {
+    return this.http.post(this.apiLangagesUrl, data, {
+      headers: new HttpHeaders({ 'Content-Type': 'application/json' })
+    });
+  }
+
+  deleteLangage(id: string): Observable<any> {
+    return this.http.delete(`${this.apiLangagesUrl}/${id}`);
+  }
+
+  updateLangage(id: string, data: any): Observable<any> {
+    return this.http.patch(`${this.apiLangagesUrl}/${id}`, data, {
+      headers: new HttpHeaders({ 'Content-Type': 'application/json' })
+    });
   }
 }

--- a/src/app/services/users.service.ts
+++ b/src/app/services/users.service.ts
@@ -10,6 +10,20 @@ export class UsersService {
 
   constructor(private http: HttpClient) { }
 
+  getAllUsers(): Observable<any[]> {
+    return this.http.get<any[]>(this.baseUrl);
+  }
+
+  createUser(data: any): Observable<any> {
+    return this.http.post(this.baseUrl, data, {
+      headers: new HttpHeaders({ 'Content-Type': 'application/json' })
+    });
+  }
+
+  deleteUser(id: string): Observable<any> {
+    return this.http.delete(`${this.baseUrl}/${id}`);
+  }
+
   update(userId: any, updatedData: any[]): Observable<any> {
     const formData = new FormData();
     for (const key in updatedData) {


### PR DESCRIPTION
## Summary
- add Material admin component
- register admin route and navigation links
- support CRUD in language, user and article services

## Testing
- `npx -p @angular/cli ng test --watch=false` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_6841c4c20358832da52f33a9a6031501