### PR TITLE
Protect admin route with role check

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -8,6 +8,7 @@ import { AuthenticationService } from './services/authentication.service';
 import { JwtInterceptorService } from './services/jwt-interceptor.service';
 import { authInterceptor } from './interceptors/auth.interceptor';
 import { mobileNotAllowedGuard } from './guards/mobile-not-allowed.guard';
+import { AdminGuard } from './guards/admin.guard';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -17,6 +18,7 @@ export const appConfig: ApplicationConfig = {
     provideHttpClient(withFetch(), withInterceptors([authInterceptor])),
     AuthenticationService,
     {provide: HTTP_INTERCEPTORS, useClass: JwtInterceptorService, multi: true},
-    mobileNotAllowedGuard
+    mobileNotAllowedGuard,
+    AdminGuard
   ],
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -20,6 +20,7 @@ import { ShopifyModalProductComponent } from './composant/shopify-modal-product/
 import { NewsDetailComponent } from './composant/news-detail/news-detail.component';
 import { PolitiqueComponent } from './composant/politique/politique.component';
 import { AdminComponent } from './core/component/admin/admin.component';
+import { AdminGuard } from './guards/admin.guard';
 
 export const routes: Routes = [
   { path: 'home', component: HomeComponent, canActivate: [mobileNotAllowedGuard] },
@@ -36,7 +37,7 @@ export const routes: Routes = [
   { path: 'signup', component: SignupComponent, canActivate: [mobileNotAllowedGuard] },
   { path: 'mentions', component: MentionsComponent },
   { path: 'privacy-policy', component: PolitiqueComponent },
-  { path: 'admin', component: AdminComponent },
+  { path: 'admin', component: AdminComponent, canActivate: [AdminGuard] },
   { path: 'release', component: ReleaseComponent, canActivate: [mobileNotAllowedGuard] },
   { path: 'profile', component: ProfileComponent, canActivate: [mobileNotAllowedGuard] },
   { path: 'confirm-email', component: VerifyEmailComponent, canActivate: [mobileNotAllowedGuard] },

--- a/src/app/guards/admin.guard.ts
+++ b/src/app/guards/admin.guard.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+import { AuthenticationService } from '../services/authentication.service';
+import { jwtDecode } from 'jwt-decode';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AdminGuard implements CanActivate {
+  constructor(private authService: AuthenticationService, private router: Router) {}
+
+  canActivate(): boolean {
+    const token = this.authService.getAccessToken();
+    if (!token) {
+      this.router.navigate(['/signup']);
+      return false;
+    }
+    try {
+      const decoded: any = jwtDecode(token);
+      if (decoded.exp * 1000 > Date.now() && decoded.role === 'admin') {
+        return true;
+      }
+    } catch {
+      // ignore decoding errors
+    }
+    this.router.navigate(['/home']);
+    return false;
+  }
+}

--- a/src/app/navigation/header/header.component.html
+++ b/src/app/navigation/header/header.component.html
@@ -29,7 +29,7 @@
             <li class="" *isDesktopOnly>
                 <a class="" routerLink="/shop" routerLinkActive="active">boutique</a>
             </li>
-            <li class="" *isDesktopOnly>
+            <li class="" *isDesktopOnly [hidden]="!isAdmin">
                 <a class="" routerLink="/admin" routerLinkActive="active">admin</a>
             </li>
         </ul>

--- a/src/app/navigation/header/header.component.ts
+++ b/src/app/navigation/header/header.component.ts
@@ -17,10 +17,12 @@ export class HeaderComponent implements OnInit {
   constructor(private authService: AuthenticationService, private router: Router) { }
   @Output() public sidenavToggle = new EventEmitter();
   authStatus: boolean = false;
+  isAdmin: boolean = false;
 
   ngOnInit(): void {
     this.authService.getAuthStatus().subscribe(status => {
       this.authStatus = status;
+      this.isAdmin = status && this.authService.getUserRole() === 'admin';
     });
   }
 

--- a/src/app/navigation/sidenav/sidenav.component.html
+++ b/src/app/navigation/sidenav/sidenav.component.html
@@ -22,7 +22,7 @@
     <a mat-list-item routerLink="/shop" (click)="onSidenavClose()">
         <mat-icon>storefront</mat-icon> <span class="nav-caption">boutique</span>
     </a>
-    <a mat-list-item routerLink="/admin" (click)="onSidenavClose()" *isDesktopOnly>
+    <a mat-list-item routerLink="/admin" (click)="onSidenavClose()" *isDesktopOnly [hidden]="!isAdmin">
         <mat-icon>admin_panel_settings</mat-icon> <span class="nav-caption">admin</span>
     </a>
 

--- a/src/app/navigation/sidenav/sidenav.component.ts
+++ b/src/app/navigation/sidenav/sidenav.component.ts
@@ -17,6 +17,7 @@ export class SidenavComponent implements OnInit {
   isAuthenticated: boolean = false;
   @Output() sidenavClose = new EventEmitter();
   authStatus: boolean = false;
+  isAdmin: boolean = false;
 
 
   constructor(
@@ -29,6 +30,7 @@ export class SidenavComponent implements OnInit {
   ngOnInit(): void {
     this.authService.getAuthStatus().subscribe((status) => {
       this.isAuthenticated = status;
+      this.isAdmin = status && this.authService.getUserRole() === 'admin';
     });
   }
 

--- a/src/app/services/authentication.service.ts
+++ b/src/app/services/authentication.service.ts
@@ -143,6 +143,11 @@ export class AuthenticationService {
     return info.id ? info.id : '';
   }
 
+  getUserRole(): string {
+    const info = this.getDecodedToken();
+    return info.role ? info.role : '';
+  }
+
   forgotPassword(email: string) {
     return this.http.post(`${this.baseUrl}/forgot-password`, { email });
   }


### PR DESCRIPTION
## Summary
- add new AdminGuard for admin access
- track admin role in AuthenticationService
- hide admin links from non-admin users
- enforce guard on admin route
- provide guard in app config

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cfaaf7d0832db6c679c913aa726d