### PR TITLE
Add missing service unit tests

### DIFF
--- a/src/app/services/device.service.spec.ts
+++ b/src/app/services/device.service.spec.ts
@@ -13,4 +13,12 @@ describe('DeviceService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('should detect mobile user agent', () => {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'iPhone',
+      configurable: true,
+    });
+    expect(service.isMobile()).toBeTrue();
+  });
 });

--- a/src/app/services/jwt-interceptor.service.spec.ts
+++ b/src/app/services/jwt-interceptor.service.spec.ts
@@ -1,19 +1,43 @@
 import { TestBed } from '@angular/core/testing';
 import { PLATFORM_ID } from '@angular/core';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
 
 import { JwtInterceptorService } from './jwt-interceptor.service';
 
 describe('JwtInterceptorService', () => {
-  let service: JwtInterceptorService;
+  let interceptor: JwtInterceptorService;
+
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [{ provide: PLATFORM_ID, useValue: 'browser' }]
+      imports: [HttpClientTestingModule],
+      providers: [
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptorService, multi: true }
+      ]
     });
-    service = TestBed.inject(JwtInterceptorService);
+    interceptor = TestBed.inject(JwtInterceptorService);
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
   });
 
   it('should be created', () => {
-    expect(service).toBeTruthy();
+    expect(interceptor).toBeTruthy();
+  });
+
+  it('should add Authorization header', () => {
+    localStorage.setItem('access_token', 'token');
+    http.get('/data').subscribe();
+    const req = httpMock.expectOne('/data');
+    expect(req.request.headers.has('Authorization')).toBeTrue();
+    expect(req.request.headers.get('Authorization')).toBe('Bearer token');
   });
 });

--- a/src/app/services/seo.service.spec.ts
+++ b/src/app/services/seo.service.spec.ts
@@ -1,4 +1,6 @@
 import { TestBed } from '@angular/core/testing';
+import { BrowserTestingModule } from '@angular/platform-browser/testing';
+import { Title, Meta } from '@angular/platform-browser';
 
 import { SeoService } from './seo.service';
 
@@ -6,11 +8,33 @@ describe('SeoService', () => {
   let service: SeoService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [BrowserTestingModule],
+      providers: [SeoService]
+    });
     service = TestBed.inject(SeoService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should update title and description', () => {
+    const title = TestBed.inject(Title);
+    const meta = TestBed.inject(Meta);
+
+    service.updateMetaData({
+      title: 'Test Title',
+      description: 'desc',
+      keywords: 'k',
+      image: '/img.png',
+      url: 'http://test'
+    });
+
+    expect(title.getTitle()).toBe('Test Title');
+    const tag = meta.getTag('name="description"');
+    expect(tag?.getAttribute('content')).toBe('desc');
+    const og = meta.getTag('property="og:title"');
+    expect(og?.getAttribute('content')).toBe('Test Title');
   });
 });

--- a/src/app/services/users.service.spec.ts
+++ b/src/app/services/users.service.spec.ts
@@ -1,16 +1,51 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { UsersService } from './users.service';
 
 describe('UsersService', () => {
   let service: UsersService;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
     service = TestBed.inject(UsersService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should fetch all users', () => {
+    service.getAllUsers().subscribe();
+    const req = httpMock.expectOne('api/users');
+    expect(req.request.method).toBe('GET');
+  });
+
+  it('should post user', () => {
+    service.createUser({ name: 'John' }).subscribe();
+    const req = httpMock.expectOne('api/users');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Content-Type')).toBe('application/json');
+  });
+
+  it('should delete user', () => {
+    service.deleteUser('1').subscribe();
+    const req = httpMock.expectOne('api/users/1');
+    expect(req.request.method).toBe('DELETE');
+  });
+
+  it('should patch user favoris', () => {
+    service.update('2', ['a']).subscribe();
+    const req = httpMock.expectOne('api/users/2');
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({ favoris: ['a'] });
   });
 });


### PR DESCRIPTION
## Summary
- add a mobile user agent check in `DeviceService`
- test metadata update logic in `SeoService`
- check Authorization header addition in `JwtInterceptorService`
- cover HTTP calls in `UsersService`

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6849b2060ac4832da5a5fe79efbb0fb2