### PR TITLE
Refactor profile error handling

### DIFF
--- a/src/app/services/profile.service.ts
+++ b/src/app/services/profile.service.ts
@@ -1,5 +1,6 @@
 import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { ErrorMessageStrategy, DefaultErrorStrategy, strategyMap } from '../shared/strategies/error-message.strategy';
 import { catchError, Observable, tap, throwError } from 'rxjs';
 
 @Injectable({
@@ -38,39 +39,19 @@ export class ProfileService {
         }
       }),
       catchError((error: HttpErrorResponse) => {
-        console.error('erreur')
+        console.error('erreur');
         let errorMessage = 'Une erreur inconnue est survenue.';
-    
-    if (error.error instanceof ErrorEvent) {
-      // Erreur côté client
-      errorMessage = `Erreur client : ${error.error.message}`;
-    } else {
-      // Erreur côté serveur
-      switch (error.status) {
-        case 400:
-          errorMessage = 'Requête invalide. Vérifiez les données envoyées.';
-          break;
-        case 401:
-          errorMessage = 'Non autorisé. Veuillez vous connecter.';
-          break;
-        case 403:
-          errorMessage = 'Accès refusé.';
-          break;
-        case 404:
-          errorMessage = "Utilisateur introuvable.";
-          break;
-        case 500:
-          errorMessage = 'Erreur serveur. Veuillez réessayer plus tard.';
-          break;
-        default:
-          errorMessage = `Erreur ${error.status}: ${error.message}`;
-      }
-    }
 
-    // Affichage d'une alerte ou d'un message d'erreur dans l'UI
-    alert(errorMessage);
+        if (error.error instanceof ErrorEvent) {
+          errorMessage = `Erreur client : ${error.error.message}`;
+        } else {
+          const strategy: ErrorMessageStrategy =
+            strategyMap.get(error.status) || new DefaultErrorStrategy();
+          errorMessage = strategy.getMessage(error);
+        }
 
-    return throwError(() => new Error(errorMessage));
+        alert(errorMessage);
+        return throwError(() => new Error(errorMessage));
       })
       
     );

--- a/src/app/shared/strategies/error-message.strategy.ts
+++ b/src/app/shared/strategies/error-message.strategy.ts
@@ -1,0 +1,48 @@
+import { HttpErrorResponse } from "@angular/common/http";
+export interface ErrorMessageStrategy {
+  getMessage(error: HttpErrorResponse): string;
+}
+
+export class BadRequestStrategy implements ErrorMessageStrategy {
+  getMessage(): string {
+    return 'Requête invalide. Vérifiez les données envoyées.';
+  }
+}
+
+export class UnauthorizedStrategy implements ErrorMessageStrategy {
+  getMessage(): string {
+    return 'Non autorisé. Veuillez vous connecter.';
+  }
+}
+
+export class ForbiddenStrategy implements ErrorMessageStrategy {
+  getMessage(): string {
+    return 'Accès refusé.';
+  }
+}
+
+export class NotFoundStrategy implements ErrorMessageStrategy {
+  getMessage(): string {
+    return 'Utilisateur introuvable.';
+  }
+}
+
+export class ServerErrorStrategy implements ErrorMessageStrategy {
+  getMessage(): string {
+    return 'Erreur serveur. Veuillez réessayer plus tard.';
+  }
+}
+
+export class DefaultErrorStrategy implements ErrorMessageStrategy {
+  getMessage(error: HttpErrorResponse): string {
+    return `Erreur ${error.status}: ${error.message}`;
+  }
+}
+
+export const strategyMap = new Map<number, ErrorMessageStrategy>([
+  [400, new BadRequestStrategy()],
+  [401, new UnauthorizedStrategy()],
+  [403, new ForbiddenStrategy()],
+  [404, new NotFoundStrategy()],
+  [500, new ServerErrorStrategy()],
+]);


### PR DESCRIPTION
## Summary
- introduce `ErrorMessageStrategy` classes to handle HTTP errors
- refactor `ProfileService` to use the strategy map

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a92c15c0c832db3d7516aae775427