### PR TITLE
Expose ads.txt

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,13 @@ const app = express();
 const angularApp = new AngularNodeAppEngine();
 
 /**
+ * Explicitly expose the ads.txt file at the root
+ */
+app.get('/ads.txt', (_req, res) => {
+  res.sendFile(join(browserDistFolder, 'ads.txt'));
+});
+
+/**
  * Example Express Rest API endpoints can be defined here.
  * Uncomment and define endpoints as necessary.
  *


### PR DESCRIPTION
## Summary
- expose `ads.txt` at the root of the Express server

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684ad84ad4f4832d9b2709595907c845