### PR TITLE
Expose ads.txt with fallback path

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6,11 +6,20 @@ import {
 } from '@angular/ssr/node';
 import express from 'express';
 import { join } from 'node:path';
+import { existsSync } from 'node:fs';
 
 const browserDistFolder = join(import.meta.dirname, '../browser');
 
 const app = express();
 const angularApp = new AngularNodeAppEngine();
+
+/**
+ * Explicitly expose the ads.txt file at the root
+ */
+app.get('/ads.txt', (_req, res) => {
+  const file = join(browserDistFolder, 'ads.txt');
+  res.sendFile(existsSync(file) ? file : join(import.meta.dirname, '../..', 'ads.txt'));
+});
 
 /**
  * Example Express Rest API endpoints can be defined here.


### PR DESCRIPTION
## Summary
- add `existsSync` import in `server.ts`
- serve `ads.txt` with a fallback path so it works during development

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684ad84ad4f4832d9b2709595907c845