### PR TITLE
Optimize SEO metadata

### DIFF
--- a/src/app/services/seo.service.spec.ts
+++ b/src/app/services/seo.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { BrowserTestingModule } from '@angular/platform-browser/testing';
 import { Title, Meta } from '@angular/platform-browser';
+import { DOCUMENT } from '@angular/common';
 
 import { SeoService } from './seo.service';
 
@@ -19,16 +20,19 @@ describe('SeoService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should update title and description', () => {
+  it('should update meta tags', () => {
     const title = TestBed.inject(Title);
     const meta = TestBed.inject(Meta);
+    const doc = TestBed.inject(DOCUMENT);
 
     service.updateMetaData({
       title: 'Test Title',
       description: 'desc',
       keywords: 'k',
       image: '/img.png',
-      url: 'http://test'
+      url: 'http://test',
+      robots: 'index,follow',
+      canonical: 'http://test'
     });
 
     expect(title.getTitle()).toBe('Test Title');
@@ -36,5 +40,8 @@ describe('SeoService', () => {
     expect(tag?.getAttribute('content')).toBe('desc');
     const og = meta.getTag('property="og:title"');
     expect(og?.getAttribute('content')).toBe('Test Title');
+
+    const canonical = doc.querySelector('link[rel="canonical"]');
+    expect(canonical?.getAttribute('href')).toBe('http://test');
   });
 });

--- a/src/app/services/seo.service.ts
+++ b/src/app/services/seo.service.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
+import { DOCUMENT } from '@angular/common';
 
 @Injectable({ providedIn: 'root' })
 export class SeoService {
-  constructor(private title: Title, private meta: Meta) {}
+  constructor(private title: Title, private meta: Meta, @Inject(DOCUMENT) private doc: Document) {}
 
   updateMetaData(options: {
     title: string;
@@ -11,6 +12,8 @@ export class SeoService {
     keywords?: string;
     image?: string;
     url?: string;
+    robots?: string;
+    canonical?: string;
   }) {
     this.title.setTitle(options.title);
 
@@ -18,6 +21,9 @@ export class SeoService {
     this.meta.updateTag({ name: 'description', content: options.description });
     if (options.keywords) {
       this.meta.updateTag({ name: 'keywords', content: options.keywords });
+    }
+    if (options.robots) {
+      this.meta.updateTag({ name: 'robots', content: options.robots });
     }
 
     // Open Graph tags
@@ -37,6 +43,16 @@ export class SeoService {
     this.meta.updateTag({ name: 'twitter:description', content: options.description });
     if (options.image) {
       this.meta.updateTag({ name: 'twitter:image', content: options.image });
+    }
+
+    if (options.canonical) {
+      let link = this.doc.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+      if (!link) {
+        link = this.doc.createElement('link');
+        link.setAttribute('rel', 'canonical');
+        this.doc.head.appendChild(link);
+      }
+      link.setAttribute('href', options.canonical);
     }
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -3,8 +3,10 @@
 
 <head>
   <meta charset="utf-8">
-  <meta name="description"
-    content="Votre source centralisée d'informations sur les langages de programmation et les outils dédiés au développement informatiqueLangages de programmation, frameworks , leur version, et les tendances">
+  <meta name="description" content="Plateforme centralisée pour suivre les versions et tendances des langages de programmation, frameworks et outils dédiés au développement." />
+  <meta name="keywords" content="verstack, langages, frameworks, outils, développement, versions, tendances" />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://verstack.io/" />
   <title>verstack.io</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary
- refine default meta tags in `index.html`
- extend `SeoService` with `robots` and `canonical` options
- update unit tests for new SEO metadata

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b10e41634832d9595269b77c6decc