### PR TITLE
Handle prerender routes explicitly

### DIFF
--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -1,8 +1,21 @@
 import { RenderMode, ServerRoute } from '@angular/ssr';
 
 export const serverRoutes: ServerRoute[] = [
+  { path: '', renderMode: RenderMode.Prerender },
+  { path: 'home', renderMode: RenderMode.Prerender },
+  { path: 'about', renderMode: RenderMode.Prerender },
+  { path: 'version', renderMode: RenderMode.Prerender },
+  { path: 'stat', renderMode: RenderMode.Prerender },
+  { path: 'shop', renderMode: RenderMode.Prerender },
+  { path: 'news', renderMode: RenderMode.Prerender },
+  { path: 'signup', renderMode: RenderMode.Prerender },
+  { path: 'mentions', renderMode: RenderMode.Prerender },
+  { path: 'privacy-policy', renderMode: RenderMode.Prerender },
+  { path: 'release', renderMode: RenderMode.Prerender },
+  { path: 'mobile-not-allowed', renderMode: RenderMode.Prerender },
+  { path: 'manifeste', renderMode: RenderMode.Prerender },
   {
     path: '**',
-    renderMode: RenderMode.Prerender
+    renderMode: RenderMode.Server
   }
 ];


### PR DESCRIPTION
## Summary
- set dedicated prerender routes and use SSR for parameterized ones

## Testing
- `npm test` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_6851c6dadbe0832db48c4c4bf256afb8