### PR TITLE
Fix server-side prerendering errors

### DIFF
--- a/src/app/composant/chart/chart.component.ts
+++ b/src/app/composant/chart/chart.component.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
-import { Component } from '@angular/core';
+import { Component, Inject, PLATFORM_ID } from '@angular/core';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { Chart, ChartItem, ChartOptions, ChartType, registerables } from 'chart.js';
 
 Chart.register(...registerables);
@@ -13,7 +14,12 @@ Chart.register(...registerables);
 })
 export class ChartComponent {
   chart: Chart | undefined;
-  chartItem: ChartItem = document.getElementById('languageChart') as ChartItem
+  chartItem!: ChartItem;
+  constructor(private http: HttpClient, @Inject(DOCUMENT) private document: Document, @Inject(PLATFORM_ID) private platformId: Object) {
+    if (isPlatformBrowser(this.platformId)) {
+      this.chartItem = this.document.getElementById('languageChart') as ChartItem;
+    }
+  }
 
   // Données du graphique
   chartColors: string[] = ['#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF',
@@ -51,12 +57,10 @@ export class ChartComponent {
   labels = ['2015', '2016', '2017', '2018', '2019', '2020', '2021', '2022', '2023', '2024', '2025'];
   fullData: any[] = [];
 
-  constructor(private http: HttpClient) {
-
-  }
-
   ngOnInit(): void {
-    this.loadTrendsData();
+    if (isPlatformBrowser(this.platformId)) {
+      this.loadTrendsData();
+    }
   }
 
   loadTrendsData(): void {
@@ -173,11 +177,15 @@ export class ChartComponent {
 
   // Fonction pour afficher les sources en dessous du graphique
 addSourcesToPage(sources: string[]): void {
-  const sourcesContainer = document.getElementById('sources-container');
+  if (!isPlatformBrowser(this.platformId)) {
+    return;
+  }
+  const sourcesContainer = this.document.getElementById('sources-container');
   const regex = /https:\/\/([^ ]+)/g;
   if (sourcesContainer) {
-    sourcesContainer.innerHTML = '<em>Sources utilisées :</em>' + sources.map(source => {  return`<p><a href='${source.match(regex)} ' target=_blank>${source}</a></p>`; }).join('');
-  
+    sourcesContainer.innerHTML = '<em>Sources utilisées :</em>' + sources.map(source => {
+      return `<p><a href='${source.match(regex)} ' target=_blank>${source}</a></p>`;
+    }).join('');
   }
 }
 

--- a/src/app/composant/shopify-buy-button/shopify-buy-button.component.ts
+++ b/src/app/composant/shopify-buy-button/shopify-buy-button.component.ts
@@ -1,8 +1,9 @@
-import { AfterViewInit, Component, EventEmitter, inject, Inject, Input, Output } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, inject, Inject, Input, Output, PLATFORM_ID } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
+import { isPlatformBrowser, DOCUMENT } from '@angular/common';
 
 @Component({
   selector: 'app-shopify-buy-button',
@@ -20,14 +21,18 @@ export class ShopifyBuyButtonComponent implements AfterViewInit {
 
 
 
-  constructor() {
-  }
+  constructor(@Inject(PLATFORM_ID) private platformId: Object, @Inject(DOCUMENT) private document: Document) {}
 
   ngAfterViewInit(): void {
-    this.initBuyButton();
+    if (isPlatformBrowser(this.platformId)) {
+      this.initBuyButton();
+    }
   }
 
   private initBuyButton() {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
     if ((window as any).ShopifyBuy) {
       if ((window as any).ShopifyBuy.UI) {
         this.createComponent();
@@ -40,14 +45,20 @@ export class ShopifyBuyButtonComponent implements AfterViewInit {
   }
 
   private loadScript() {
-    const script = document.createElement('script');
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+    const script = this.document.createElement('script');
     script.async = true;
     script.src = 'https://sdks.shopifycdn.com/buy-button/latest/buy-button-storefront.min.js';
     script.onload = () => this.createComponent();
-    document.head.appendChild(script);
+    this.document.head.appendChild(script);
   }
 
   private createComponent() {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
     const ShopifyBuy = (window as any).ShopifyBuy;
     const client = ShopifyBuy.buildClient({
       domain: 's8h1eq-f8.myshopify.com',
@@ -57,7 +68,7 @@ export class ShopifyBuyButtonComponent implements AfterViewInit {
     ShopifyBuy.UI.onReady(client).then((ui: any) => {
       ui.createComponent('product', {
         id: `${this.productId}`,
-        node: document.getElementById(`${this.componentId}`),
+        node: this.document.getElementById(`${this.componentId}`),
         moneyFormat: '%E2%82%AC%7B%7Bamount_with_comma_separator%7D%7D',
         options: {
           "product": {
@@ -149,7 +160,7 @@ export class ShopifyBuyButtonComponent implements AfterViewInit {
           "toggle": {}
         },
       });
-      const container = document.getElementById(`${this.componentId}`);
+      const container = this.document.getElementById(`${this.componentId}`);
 
       const observer = new MutationObserver(() => {
         const iframe = container?.querySelector('iframe');

--- a/src/app/core/component/shop/shop.component.ts
+++ b/src/app/core/component/shop/shop.component.ts
@@ -1,5 +1,5 @@
 // shop.component.ts
-import { AfterViewInit, Component, inject, OnInit } from '@angular/core';
+import { AfterViewInit, Component, inject, OnInit, Inject, PLATFORM_ID } from '@angular/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { ShopifyBuyButtonComponent } from '../../../composant/shopify-buy-button/shopify-buy-button.component';
@@ -10,7 +10,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
 import { MatPaginatorModule, PageEvent, MatPaginatorIntl } from '@angular/material/paginator';
-import { CommonModule } from '@angular/common';
+import { CommonModule, isPlatformBrowser, DOCUMENT } from '@angular/common';
 import { SeoService } from '../../../services/seo.service';
 import { ProductsService } from '../../../services/products.service';
 
@@ -102,7 +102,8 @@ export class ShopComponent implements AfterViewInit, OnInit {
 
 
 
-  constructor(private titleService: Title, private metaService: Meta, private seo: SeoService, private productsService: ProductsService) { }
+  constructor(private titleService: Title, private metaService: Meta, private seo: SeoService, private productsService: ProductsService,
+              @Inject(PLATFORM_ID) private platformId: Object, @Inject(DOCUMENT) private document: Document) { }
 
   ngOnInit(): void {
     this.seo.updateMetaData({
@@ -124,8 +125,11 @@ export class ShopComponent implements AfterViewInit, OnInit {
   }
 
   ngAfterViewInit() {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
 
-    const asides = document.querySelectorAll('aside');
+    const asides = this.document.querySelectorAll('aside');
     if (!asides) return;
 
     asides.forEach((aside: any) => {

--- a/src/app/core/component/stat/stat.component.ts
+++ b/src/app/core/component/stat/stat.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Inject, PLATFORM_ID } from '@angular/core';
 import { ChartComponent } from "../../../composant/chart/chart.component";
 import { SeoService } from '../../../services/seo.service';
+import { isPlatformBrowser } from '@angular/common';
 
 @Component({
   selector: 'app-stat',
@@ -9,14 +10,15 @@ import { SeoService } from '../../../services/seo.service';
   styleUrl: './stat.component.scss'
 })
 export class StatComponent implements OnInit {
-  constructor(private seo: SeoService) { }
+  constructor(private seo: SeoService, @Inject(PLATFORM_ID) private platformId: Object) { }
 
   ngOnInit(): void {
+    const imageUrl = isPlatformBrowser(this.platformId) ? `${window.location.origin}/assets/slider/slider-1.jpg` : '';
     this.seo.updateMetaData({
       title: 'Statistiques – Verstack.io',
       description: 'Explorez les statistiques des langages de programmation et des outils de développement.',
       keywords: 'statistiques, langages, outils, développeurs, Angular, React',
-      image: `${window.location.origin}/assets/slider/slider-1.jpg`,
+      image: imageUrl,
       url: 'https://verstack.io/stat'
     });
   }

--- a/src/app/core/component/version/version.component.ts
+++ b/src/app/core/component/version/version.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, Input, OnInit, Inject, PLATFORM_ID } from '@angular/core';
 import { Field } from '../../../models/field.model';
 import { LangagesService } from '../../../services/langages.service';
 import { MatTabsModule } from '@angular/material/tabs';
@@ -8,7 +8,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { AuthenticationService } from '../../../services/authentication.service';
 import { ProfileService } from '../../../services/profile.service';
-import { CommonModule } from '@angular/common';
+import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { Observable, tap } from 'rxjs';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { differenceInMonths, parseISO } from 'date-fns';
@@ -88,9 +88,11 @@ export class VersionComponent implements OnInit {
     private _langagesService: LangagesService,
     private authService: AuthenticationService,
     private profileService: ProfileService,
-    private title: Title, private meta: Meta,
+    private title: Title,
+    private meta: Meta,
     private seo: SeoService,
-  ) { }
+    @Inject(PLATFORM_ID) private platformId: Object
+  ) {}
 
   ngOnInit(): void {
     this.seo.updateMetaData({
@@ -111,21 +113,25 @@ export class VersionComponent implements OnInit {
   }
 
   private loadUserData(): void {
-    const storedUserData = localStorage.getItem('user');
-    if (storedUserData) {
-      this.userData = JSON.parse(storedUserData);
-    } else {
-      this.userData = null;
+    if (isPlatformBrowser(this.platformId)) {
+      const storedUserData = localStorage.getItem('user');
+      if (storedUserData) {
+        this.userData = JSON.parse(storedUserData);
+      } else {
+        this.userData = null;
+      }
     }
   }
 
   private loadUserFavoris(): void {
-    const storedUserFavoris = localStorage.getItem('favoris');
+    if (isPlatformBrowser(this.platformId)) {
+      const storedUserFavoris = localStorage.getItem('favoris');
 
-    if (storedUserFavoris && storedUserFavoris.length !== 0) {
-      this.userFavoris = JSON.parse(localStorage.getItem('favoris') || '[]');
-    } else {
-      this.userFavoris = null;
+      if (storedUserFavoris && storedUserFavoris.length !== 0) {
+        this.userFavoris = JSON.parse(localStorage.getItem('favoris') || '[]');
+      } else {
+        this.userFavoris = null;
+      }
     }
   }
 
@@ -225,8 +231,10 @@ export class VersionComponent implements OnInit {
     }
   }
   private storeUserData(response: any) {
-    // localStorage.setItem('user', JSON.stringify(response));
-    localStorage.setItem('favoris', JSON.stringify(response.favoris));
+    if (isPlatformBrowser(this.platformId)) {
+      // localStorage.setItem('user', JSON.stringify(response));
+      localStorage.setItem('favoris', JSON.stringify(response.favoris));
+    }
   }
 
   private updateUserFavoris(updatedData: any): void {
@@ -269,7 +277,9 @@ export class VersionComponent implements OnInit {
   }
 
   redirectTo(url: string): void {
-    window.open(url, '_blank');
+    if (isPlatformBrowser(this.platformId)) {
+      window.open(url, '_blank');
+    }
   }
 
   needLoginDialog(): void {

--- a/src/app/services/articles.service.ts
+++ b/src/app/services/articles.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Injectable, Inject, PLATFORM_ID } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { isPlatformServer } from '@angular/common';
 
 interface Article {
   title: string;
@@ -15,14 +16,20 @@ interface Article {
 export class ArticlesService {
 
   private apiUrl = 'api/news';
-  
-  constructor(private http: HttpClient) { }
+
+  constructor(private http: HttpClient, @Inject(PLATFORM_ID) private platformId: Object) { }
 
   getArticles(): Observable<Article[]> {
+    if (isPlatformServer(this.platformId)) {
+      return of([]);
+    }
     return this.http.get<Article[]>(`${this.apiUrl}/all`);
   }
 
   getArticleById(id: string): Observable<Article> {
+    if (isPlatformServer(this.platformId)) {
+      return of({} as Article);
+    }
     return this.http.get<Article>(`${this.apiUrl}/${id}`);
   }
 

--- a/src/app/services/device.service.ts
+++ b/src/app/services/device.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 
 @Injectable({
   providedIn: 'root'
@@ -6,10 +7,12 @@ import { Injectable } from '@angular/core';
 export class DeviceService {
   private readonly mobileRegex = /iPhone|iPad|iPod|Android/i;
 
-  
-  
-  isMobile() {
-   return this.mobileRegex.test(navigator.userAgent);
+  constructor(@Inject(PLATFORM_ID) private platformId: Object) {}
 
+  isMobile(): boolean {
+    if (isPlatformBrowser(this.platformId)) {
+      return this.mobileRegex.test(navigator.userAgent);
+    }
+    return false;
   }
 }

--- a/src/app/services/langages.service.ts
+++ b/src/app/services/langages.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Injectable } from '@angular/core';
-import { map, Observable } from 'rxjs';
+import { Injectable, Inject, PLATFORM_ID } from '@angular/core';
+import { map, Observable, of } from 'rxjs';
+import { isPlatformServer } from '@angular/common';
 
 @Injectable({
   providedIn: 'root'
@@ -10,14 +11,17 @@ export class LangagesService {
 
   private apiLangagesUrl = 'api/langages';
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient, @Inject(PLATFORM_ID) private platformId: Object) { }
 
   getAllLangages(): Observable<any[]> {
+    if (isPlatformServer(this.platformId)) {
+      return of([]);
+    }
     return this.http.get<any[]>(`${this.apiLangagesUrl}/all`).pipe(
       map((langages: any) => {
-      return  langages.sort((a: any,b: any) => (b.recommendations ?? 0) - (a.recommendations ?? 0))
+        return langages.sort((a: any, b: any) => (b.recommendations ?? 0) - (a.recommendations ?? 0));
       })
-    )
+    );
   }
 
   createLangage(data: any): Observable<any> {

--- a/src/app/shared/is-mobile-only.directive.ts
+++ b/src/app/shared/is-mobile-only.directive.ts
@@ -16,7 +16,7 @@ export class IsMobileOnlyDirective {
   ) { }
 
   ngOnInit() {
-    if (this.deviceService.isMobile()) {
+    if (isPlatformBrowser(this.platformId) && this.deviceService.isMobile()) {
       this.viewContainer.createEmbeddedView(this.templateRef);
     } else {
       this.viewContainer.clear();


### PR DESCRIPTION
## Summary
- guard device detection with platform checks
- skip client-only logic during server prerendering
- avoid DOM access on the server for chart and shop components
- return empty results for API calls during prerender

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run build` *(fails to prerender all routes)*

------
https://chatgpt.com/codex/tasks/task_e_6851c94a9ad8832db728caa5adbefa38