### PR TITLE
Fix SSR snackbar errors

### DIFF
--- a/src/app/account/forgot-password/forgot-password.component.ts
+++ b/src/app/account/forgot-password/forgot-password.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, Inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { AuthenticationService } from '../../services/authentication.service';
@@ -26,8 +27,14 @@ export class ForgotPasswordComponent {
     private _snackBar = inject(MatSnackBar);
     durationInSeconds = 5;
     selected: number = 0
+  private isBrowser: boolean;
 
-  constructor(private fb: FormBuilder, private authService: AuthenticationService) {
+  constructor(
+    private fb: FormBuilder,
+    private authService: AuthenticationService,
+    @Inject(PLATFORM_ID) platformId: Object
+  ) {
+    this.isBrowser = isPlatformBrowser(platformId);
     this.forgotPasswordForm = this.fb.group({
       email: ['', [Validators.required, Validators.email]],
     });
@@ -53,6 +60,7 @@ export class ForgotPasswordComponent {
   }
 
   openSnackBar(message: string) {
+    if (!this.isBrowser) return;
     this._snackBar.open(message, '', {
       duration: this.durationInSeconds * 1000,
       horizontalPosition: 'center',

--- a/src/app/account/login/login.component.ts
+++ b/src/app/account/login/login.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, Inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -23,9 +24,16 @@ import {MatSnackBar} from '@angular/material/snack-bar';
 export class LoginComponent {
   loginForm: FormGroup;
   private _snackBar = inject(MatSnackBar);
+  private isBrowser: boolean;
 
 
-  constructor(private fb: FormBuilder, private readonly authService: AuthenticationService, private router: Router) {
+  constructor(
+    private fb: FormBuilder,
+    private readonly authService: AuthenticationService,
+    private router: Router,
+    @Inject(PLATFORM_ID) platformId: Object
+  ) {
+    this.isBrowser = isPlatformBrowser(platformId);
 
     this.loginForm = this.fb.group({
       email: ['', [Validators.required, Validators.email]],
@@ -53,6 +61,7 @@ export class LoginComponent {
   durationInSeconds = 5;
 
   openSnackBar(message: string) {
+    if (!this.isBrowser) return;
     this._snackBar.open(message, '', {
       duration: this.durationInSeconds * 1000,
       horizontalPosition: 'center',

--- a/src/app/account/profile/profile.component.ts
+++ b/src/app/account/profile/profile.component.ts
@@ -171,6 +171,7 @@ export class ProfileComponent implements OnInit {
   durationInSeconds = 5;
 
   openSnackBar(message: string) {
+    if (!this.isBrowser) return;
     this._snackBar.open(message, '', {
       duration: this.durationInSeconds * 1000,
       horizontalPosition: 'center',

--- a/src/app/account/signin/signin.component.ts
+++ b/src/app/account/signin/signin.component.ts
@@ -15,7 +15,8 @@ import { MatInputModule } from '@angular/material/input';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 
-import { Component, EventEmitter, inject, Output, ViewEncapsulation, OnInit } from '@angular/core';
+import { Component, EventEmitter, inject, Output, ViewEncapsulation, OnInit, Inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { TermesComponent } from '../../composant/termes/termes.component';
@@ -52,6 +53,7 @@ export class SigninComponent implements OnInit {
   private _snackBar = inject(MatSnackBar);
   durationInSeconds = 5;
   selected: number = 0
+  private isBrowser: boolean;
 
   openPrivacyTermeDialog() {
     const dialogRef = this.dialog.open(TermesComponent);
@@ -73,8 +75,10 @@ export class SigninComponent implements OnInit {
     private fb: FormBuilder,
     private authService: AuthenticationService,
     private router: Router,
-    private jobListService: JobListService
+    private jobListService: JobListService,
+    @Inject(PLATFORM_ID) platformId: Object
   ) {
+    this.isBrowser = isPlatformBrowser(platformId);
     this.signupForm = this.fb.group(
       {
         sexe: [''],
@@ -148,6 +152,7 @@ export class SigninComponent implements OnInit {
 
 
   openSnackBar(message: string) {
+    if (!this.isBrowser) return;
     this._snackBar.open(message, '', {
       duration: this.durationInSeconds * 1000,
       horizontalPosition: 'center',


### PR DESCRIPTION
## Summary
- guard snackbar calls with `isPlatformBrowser` checks to avoid SSR errors

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853bfc7cf18832d96902aa18c4bb281