### PR TITLE
Fix optional chaining warnings

### DIFF
--- a/src/app/core/component/news/news.component.html
+++ b/src/app/core/component/news/news.component.html
@@ -14,7 +14,7 @@
                 <input matInput placeholder="Tapez un mot-clé">
             </mat-form-field>-->
 
-                @if(actualiteType?.length > 0) {
+                @if(actualiteType.length > 0) {
                 <mat-chip-listbox>
                     @for(type of actualiteType; track type; let i = $index) {
                     <mat-chip-option (selectionChange)="filterByType(i)"> {{ type }}</mat-chip-option>

--- a/src/app/core/component/version/version.component.html
+++ b/src/app/core/component/version/version.component.html
@@ -69,7 +69,7 @@
                 matTooltip="Popularité *Stackoverflow" matBadgeDescription="Popularité"
                 [matBadge]="language.recommendations" aria-label="Popularité">🔥</button>}
 
-              @if(authStatus && favorisFromHome?.length == 0 ){ <a mat-icon-button aria-label="épingler"
+              @if(authStatus && favorisFromHome.length == 0 ){ <a mat-icon-button aria-label="épingler"
                 matTooltip="{{(isPinned(language.name) ? 'Retirer ' : 'Ajouter ') + language.name + ' à votre board'}}"
                 aria-label="Bouton qui ajoute la carte au tableau personnalisé" (click)="pinLanguage(language)">
                 <mat-icon aria-hidden="true" aria-label="épingle icone"

--- a/src/app/core/mobile-not-allowed/mobile-not-allowed.component.html
+++ b/src/app/core/mobile-not-allowed/mobile-not-allowed.component.html
@@ -21,7 +21,7 @@
             <h2>{{ slide.title }}</h2>
             <p>{{ slide.text }}</p>
 
-            @if(i === slides?.length - 1){
+            @if(i === slides.length - 1){
               <button mat-stroked-button color="accent" (click)="redirectToDesktop()">
                 Accéder à la version desktop
               </button>


### PR DESCRIPTION
## Summary
- drop unnecessary non-null assertions in the HTML templates
  - `news.component.html`
  - `version.component.html`
  - `mobile-not-allowed.component.html`

## Testing
- `npm test` *(fails: Could not find the '@angular-devkit/build-angular:karma' builder)*

------
https://chatgpt.com/codex/tasks/task_e_6853c66d143c832d8acec57edeeb2553