### PR TITLE
Add tooltip with release freshness

### DIFF
--- a/src/app/core/component/version/version.component.html
+++ b/src/app/core/component/version/version.component.html
@@ -11,7 +11,7 @@
   </div>}
   <section>
     @if(!isLoading){<div>
-     @if(origin !== 'home'){<mat-tab-group [(selectedIndex)]="selectedDomainIndex">
+     @if(origin() !== 'home'){<mat-tab-group [(selectedIndex)]="selectedDomainIndex">
         @for(domain of domaines; track domain; let i = $index ){<mat-tab (click)="selectedDomain = domain">
           <ng-template mat-tab-label>{{ domain }}</ng-template>
         </mat-tab>}
@@ -23,7 +23,13 @@
           <mat-card class="language-card" appearance="outlined">
             <mat-card-header>
               <mat-card-title-group>
-                <mat-card-title>{{ language.name }} </mat-card-title>
+                <mat-card-title>
+                  {{ language.name }}
+                  <span class="status-indicator"
+                        [ngClass]="getDataStatusClass(language.versions[0]?.releaseDate)"
+                        [matTooltip]="getDataStatusTooltip(language.versions[0]?.releaseDate)"
+                        matTooltipPosition="above"></span>
+                </mat-card-title>
                 <mat-card-subtitle>
                   <mat-icon [ngClass]="getIconColor(language.domain)">
                     {{getIconType(language.domain)}}
@@ -69,7 +75,7 @@
                 matTooltip="Popularité *Stackoverflow" matBadgeDescription="Popularité"
                 [matBadge]="language.recommendations" aria-label="Popularité">🔥</button>}
 
-              @if(authStatus && favorisFromHome.length == 0 ){ <a mat-icon-button aria-label="épingler"
+              @if(authStatus && favorisFromHome()?.length == 0 ){ <a mat-icon-button aria-label="épingler"
                 matTooltip="{{(isPinned(language.name) ? 'Retirer ' : 'Ajouter ') + language.name + ' à votre board'}}"
                 aria-label="Bouton qui ajoute la carte au tableau personnalisé" (click)="pinLanguage(language)">
                 <mat-icon aria-hidden="true" aria-label="épingle icone"

--- a/src/app/core/component/version/version.component.scss
+++ b/src/app/core/component/version/version.component.scss
@@ -117,6 +117,22 @@
   /* vert material */
 }
 
+.status-indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-left: 4px;
+}
+
+.status-ok {
+  background-color: #4caf50;
+}
+
+.status-ko {
+  background-color: #f44336;
+}
+
 
 .support-primary {
   @include mat.progress-bar-overrides((active-indicator-color: green,


### PR DESCRIPTION
## Summary
- show a small status circle on version cards
- compute card status by comparing the release date to today
- display distance to the release date in the tooltip

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686022820a00832db435e62dacfbba96